### PR TITLE
feat: cache aus docker-compose datei entfernt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   database:
     container_name: database
     image: postgis/postgis:13-master
+    ports:
+      - 5444:5432
     # Required when running on platform other than amd64, like Apple M1/M2:
     # platform: linux/amd64
     volumes:
@@ -13,12 +15,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-  cache:
-    container_name: cache
-    image: redis:6
-    networks:
-      - directus
-
   directus:
     container_name: directus
     image: directus/directus:latest
@@ -29,14 +25,9 @@ services:
       # Always make sure your volumes matches the storage root when using
       # local driver
       - ./uploads:/directus/uploads
-      # Make sure to also mount the volume when using SQLite
-      # - ./database:/directus/database
-      # If you want to load extensions from the host
-      # - ./extensions:/directus/extensions
     networks:
       - directus
     depends_on:
-      - cache
       - database
     environment:
       KEY: ${KEY}
@@ -48,10 +39,6 @@ services:
       DB_DATABASE: ${POSTGRES_DB}
       DB_USER: ${POSTGRES_USER}
       DB_PASSWORD: ${POSTGRES_PASSWORD}
-
-      CACHE_ENABLED: ${CACHE_ENABLED}
-      CACHE_STORE: ${CACHE_STORE}
-      CACHE_REDIS: ${CACHE_REDIS}
 
       ADMIN_EMAIL: ${ADMIN_EMAIL}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}


### PR DESCRIPTION
- Da die Produktions-Instanz aktuell ohne Cache läuft, wurde das Setting aus der docker-compose-Datei ebenfalls entfernt
- Die Datenbank des Containers ist nun über den Port 5444 auf dem Hostsystem erreichbar