### PR TITLE
feat: cache wieder in docker-compose.yml eingefügt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,13 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+
+  cache:
+    container_name: cache
+    image: redis:6
+    networks:
+      - directus
+
   directus:
     container_name: directus
     image: directus/directus:latest
@@ -28,6 +35,7 @@ services:
     networks:
       - directus
     depends_on:
+      - cache
       - database
     environment:
       KEY: ${KEY}


### PR DESCRIPTION
- Aufgrund des geplanten Umzug des Backends zu linode wurde der cache wieder eingefügt