### PR TITLE
fix: markdown und html einbettung nach reload korrigiert

### DIFF
--- a/src/routes/(blog)/13-clans/+page.server.ts
+++ b/src/routes/(blog)/13-clans/+page.server.ts
@@ -10,10 +10,8 @@ export const load = (async () => {
 		.array()
 		.parse((await directus.items('was_sind_clans').readByQuery({ limit: 1 })).data);
 
-	const beschreibungCompiled = data.length !== 1 ? undefined : await compile(data[0].beschreibung);
-
 	return {
 		clans: clan.array().parse((await clansResponse).data),
-		beschreibung: beschreibungCompiled?.code
+		beschreibung: await compile(data[0].beschreibung)
 	};
 }) satisfies PageServerLoad;

--- a/src/routes/(blog)/13-clans/+page.svelte
+++ b/src/routes/(blog)/13-clans/+page.svelte
@@ -2,6 +2,7 @@
 	import { ScreenSize } from '$lib/types/sceenSize';
 	import { SektenName } from '$lib/types/sektenName';
 	import { A, Button, ButtonGroup, Heading, Img, P } from 'flowbite-svelte';
+	import { onMount } from 'svelte';
 	import { writable } from 'svelte/store';
 	import type { PageData } from './$types';
 
@@ -9,6 +10,7 @@
 
 	let width: number;
 	let sectFilter = writable('.*');
+	let beschreibungCompiled = '';
 
 	$: clans = data.clans.filter((e) => e.sekte?.match($sectFilter));
 
@@ -19,6 +21,10 @@
 			sectFilter.set(filter);
 		}
 	}
+
+	onMount(() => {
+		beschreibungCompiled = data.beschreibung?.code ?? '';
+	});
 </script>
 
 <svelte:window bind:innerWidth={width} />
@@ -26,7 +32,7 @@
 <Heading tag="h1" class="mb-4">Die 13 großen Vampir-Clans</Heading>
 
 <P class="mb-4 border-2 border-gray-600 shadow-md p-2 text-justify">
-	{@html data.beschreibung}
+	{@html beschreibungCompiled}
 </P>
 
 <div class="flex justify-center mb-4">

--- a/src/routes/(blog)/impressum/+page.svelte
+++ b/src/routes/(blog)/impressum/+page.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
 	import { Heading, P } from 'flowbite-svelte';
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
+
+	let copyrightNotice = '';
+	let haftungsausschluss = '';
+
+	onMount(() => {
+		copyrightNotice = data.impressum?.copyright_notice ?? '';
+		haftungsausschluss = data.impressum?.haftungsausschluss ?? '';
+	});
 </script>
 
 <Heading tag="h1" class="mb-4">Impressum</Heading>
@@ -56,6 +65,6 @@
 {/if}
 
 <Heading tag="h2" class="mt-2">Copyright</Heading>
-<P>{@html data.impressum?.copyright_notice}</P>
+<P>{@html copyrightNotice}</P>
 <Heading tag="h2" class="mt-2">Haftungsausschluss</Heading>
-<P>{@html data.impressum?.haftungsausschluss}</P>
+<P>{@html haftungsausschluss}</P>

--- a/src/routes/(blog)/was-ist-vampire-live/+page.svelte
+++ b/src/routes/(blog)/was-ist-vampire-live/+page.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
 	import { Heading, P } from 'flowbite-svelte';
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
+
+	let erklaerung = '';
+
+	onMount(() => {
+		erklaerung = data.wasIstVampireLive?.erklaerung ?? '';
+	});
 </script>
 
 <Heading tag="h1" class="mb-4">
 	{data.wasIstVampireLive?.ueberschrift}
 </Heading>
-<P class="text-justify">{@html data.wasIstVampireLive?.erklaerung}</P>
+<P class="text-justify">{@html erklaerung}</P>

--- a/src/routes/camarilla/(blog)/uebersicht/+page.server.ts
+++ b/src/routes/camarilla/(blog)/uebersicht/+page.server.ts
@@ -11,9 +11,6 @@ export const load = (async () => {
 
 	const data = response.length !== 1 ? undefined : response[0];
 
-	const beschreibungCompiled = data?.beschreibung ? await compile(data.beschreibung) : undefined;
-	const spieltermineCompiled = data?.spieltermine ? await compile(data.spieltermine) : undefined;
-
 	const camarillaBilder = directus.items('camarilla_uebersicht_files').readByQuery({
 		filter: {
 			camarilla_uebersicht_id: {
@@ -23,8 +20,8 @@ export const load = (async () => {
 	});
 
 	return {
-		beschreibung: beschreibungCompiled,
-		spieltermine: spieltermineCompiled,
+		beschreibung: compile(data?.beschreibung ?? ''),
+		spieltermine: compile(data?.spieltermine ?? ''),
 		email: data?.email,
 		discord: data?.discord,
 		bilder: camarillaUebersichtFiles.array().parse((await camarillaBilder).data)

--- a/src/routes/camarilla/(blog)/uebersicht/+page.svelte
+++ b/src/routes/camarilla/(blog)/uebersicht/+page.svelte
@@ -1,25 +1,30 @@
 <script lang="ts">
 	import ProjektUebersicht from '$lib/components/projektUebersicht.svelte';
 	import { getImageUrl } from '$lib/util';
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
 
-	let showThumbs = false;
-	let showCaptions = false;
-	let showIndicators = false;
 	let images = data.bilder?.map((e) => {
 		return {
 			id: e.camarilla_uebersicht_id,
 			imgurl: getImageUrl(e.directus_files_id)
 		};
 	});
+	let beschreibung = '';
+	let spieltermine = '';
+
+	onMount(() => {
+		beschreibung = data.beschreibung?.code ?? '';
+		spieltermine = data.spieltermine?.code ?? '';
+	});
 </script>
 
 <ProjektUebersicht
 	titel="Vampire Live - Camarilla"
-	beschreibung={data.beschreibung?.code ?? ''}
-	spieltermine={data.spieltermine?.code ?? ''}
+	{beschreibung}
+	{spieltermine}
 	email={data.email ?? ''}
 	{images}
 />

--- a/src/routes/sabbat/(blog)/setting-steckbrief/+page.server.ts
+++ b/src/routes/sabbat/(blog)/setting-steckbrief/+page.server.ts
@@ -10,7 +10,5 @@ export const load = (async () => {
 
 	const data = response.length !== 1 ? undefined : response[0];
 
-	const beschreibungCompiled = data?.beschreibung ? await compile(data.beschreibung) : undefined;
-
-	return { steckbrief: data, beschreibung: beschreibungCompiled };
+	return { steckbrief: data, beschreibung: compile(data?.beschreibung ?? '') };
 }) satisfies PageServerLoad;

--- a/src/routes/sabbat/(blog)/setting-steckbrief/+page.svelte
+++ b/src/routes/sabbat/(blog)/setting-steckbrief/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import { Heading, Li, List, P } from 'flowbite-svelte';
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
 	const { steckbrief, beschreibung } = data;
+
+	let beschreibungCompiled = '';
+
+	onMount(() => {
+		beschreibungCompiled = beschreibung?.code ?? '';
+	});
 </script>
 
 <Heading tag="h1" class="mb-4">Setting Steckbrief</Heading>
@@ -22,7 +29,7 @@
 	class={`[&>p]:first-letter:text-2xl [&>p]::text-2xl [&>p]:text-justify [&>p]:mb-2 [&>h2]:text-4xl [&>h2]:font-bold [&>h3]:text-3xl [&>h3]:font-bold text-gray-900 dark:text-white w-full ` +
 		`[&>p>a]:underline [&>p>a]:decoration-dotted`}
 >
-	{@html beschreibung?.code}
+	{@html beschreibungCompiled}
 </P>
 
 <Heading tag="h3" class="mb-1">Regeln</Heading>

--- a/src/routes/sabbat/(blog)/uebersicht/+page.server.ts
+++ b/src/routes/sabbat/(blog)/uebersicht/+page.server.ts
@@ -11,9 +11,6 @@ export const load = (async () => {
 
 	const data = response.length !== 1 ? undefined : response[0];
 
-	const beschreibungCompiled = data?.beschreibung ? await compile(data.beschreibung) : undefined;
-	const spieltermineCompiled = data?.spieltermine ? await compile(data.spieltermine) : undefined;
-
 	const sabbatBilder = directus.items('sabbat_uebersicht_files').readByQuery({
 		filter: {
 			sabbat_uebersicht_id: {
@@ -23,8 +20,8 @@ export const load = (async () => {
 	});
 
 	return {
-		beschreibung: beschreibungCompiled,
-		spieltermine: spieltermineCompiled,
+		beschreibung: compile(data?.beschreibung ?? ''),
+		spieltermine: compile(data?.spieltermine ?? ''),
 		email: data?.email,
 		discord: data?.discord,
 		bilder: sabbatUebersichtFiles.array().parse((await sabbatBilder).data)

--- a/src/routes/sabbat/(blog)/uebersicht/+page.svelte
+++ b/src/routes/sabbat/(blog)/uebersicht/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ProjektUebersicht from '$lib/components/projektUebersicht.svelte';
 	import { getImageUrl } from '$lib/util';
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -11,12 +12,19 @@
 			imgurl: getImageUrl(e.directus_files_id)
 		};
 	});
+	let beschreibung = '';
+	let spieltermine = '';
+
+	onMount(() => {
+		beschreibung = data.beschreibung?.code ?? '';
+		spieltermine = data.spieltermine?.code ?? '';
+	});
 </script>
 
 <ProjektUebersicht
 	titel="Vampire Live - Sabbat"
-	beschreibung={data.beschreibung?.code ?? ''}
-	spieltermine={data.spieltermine?.code ?? ''}
+	{beschreibung}
+	{spieltermine}
 	email={data.email ?? ''}
 	{images}
 />

--- a/src/routes/verein/(blog)/kontakt/+page.svelte
+++ b/src/routes/verein/(blog)/kontakt/+page.svelte
@@ -6,8 +6,8 @@
 	export let data: PageData;
 </script>
 
-<Heading tag="h2" class="mb-2">Kontakt</Heading>
-<Heading tag="h3" class="mb-2">Social-Media</Heading>
+<Heading tag="h1" class="mb-4">Kontakt</Heading>
+<Heading tag="h2" class="mb-2">Social-Media</Heading>
 <P align="center">Der Verein ist auf den folgenden Social-Media-Kanälen vertreten.</P>
 <div class="flex flex-col md:flex-row gap-1 w-50 mt-2 mb-4 justify-center">
 	<SocialButton icon="discord" />
@@ -15,19 +15,19 @@
 	<SocialButton icon="instagram" />
 </div>
 
-<Heading tag="h3" class="mb-2">E-Mail</Heading>
+<Heading tag="h2" class="mb-2">E-Mail</Heading>
 <P align="center">
 	Der Verein und seine Projekte können über die folgenden E-Mail-Adressen kontaktiert werden.
 </P>
 
-<Heading tag="h4" class="mb-1">Verein</Heading>
+<Heading tag="h3" class="mb-1">Verein</Heading>
 <div class="flex flex-col md:flex-row gap-1 w-50 mt-2 mb-4 justify-center">
 	<SocialButton icon="email" href={`mailto:${data.kontakt.email_allgemein}`} text="Allgemein" />
 	<SocialButton icon="email" href={`mailto:${data.kontakt.email_vorstand}`} text="Vorstand" />
 	<SocialButton icon="email" href={`mailto:${data.kontakt.email_webmaster}`} text="Webmaster" />
 </div>
 
-<Heading tag="h4" class="mb-2">Projekte</Heading>
+<Heading tag="h3" class="mb-2">Projekte</Heading>
 <div class="flex flex-col md:flex-row gap-1 w-50 mt-2 mb-4 justify-center">
 	<SocialButton
 		icon="email"

--- a/src/routes/verein/(blog)/paragraph-86-und-86a/+page.server.ts
+++ b/src/routes/verein/(blog)/paragraph-86-und-86a/+page.server.ts
@@ -10,9 +10,7 @@ export const load = (async () => {
 
 	const data = response.length !== 1 ? undefined : response[0];
 
-	const paragraph86und86aCompiled = data?.inhalt ? await compile(data.inhalt) : undefined;
-
 	return {
-		paragraph86und86aCompiled: paragraph86und86aCompiled
+		paragraph86und86aCompiled: compile(data?.inhalt ?? '')
 	};
 }) satisfies PageServerLoad;

--- a/src/routes/verein/(blog)/paragraph-86-und-86a/+page.svelte
+++ b/src/routes/verein/(blog)/paragraph-86-und-86a/+page.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
 	import { Heading, P } from 'flowbite-svelte';
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
+
+	let paragraph86und86a = '';
+
+	onMount(() => {
+		paragraph86und86a = data.paragraph86und86aCompiled?.code ?? '';
+	});
 </script>
 
-<Heading tag="h1">
+<Heading tag="h1" class="mb-4">
 	Hinweis zu Verfassungsfeindlichen Organisationen und deren Propagandamaterial
 </Heading>
 <P
@@ -13,5 +20,5 @@
 	class={`[&>p]:first-letter:text-2xl [&>p]::text-2xl [&>p]:text-justify [&>p]:mb-2 [&>h2]:text-4xl [&>h2]:font-bold [&>h3]:text-3xl [&>h3]:font-bold text-gray-900 dark:text-white w-full ` +
 		`[&>p>a]:underline [&>p>a]:decoration-dotted`}
 >
-	{@html data.paragraph86und86aCompiled?.code}
+	{@html paragraph86und86a}
 </P>

--- a/src/routes/w40k/(blog)/uebersicht/+page.server.ts
+++ b/src/routes/w40k/(blog)/uebersicht/+page.server.ts
@@ -11,9 +11,6 @@ export const load = (async () => {
 
 	const data = response.length !== 1 ? undefined : response[0];
 
-	const beschreibungCompiled = data?.beschreibung ? await compile(data.beschreibung) : undefined;
-	const spieltermineCompiled = data?.spieltermine ? await compile(data.spieltermine) : undefined;
-
 	const w40kBilder = directus.items('w40k_uebersicht_files').readByQuery({
 		filter: {
 			w40k_uebersicht_id: {
@@ -23,8 +20,8 @@ export const load = (async () => {
 	});
 
 	return {
-		beschreibung: beschreibungCompiled,
-		spieltermine: spieltermineCompiled,
+		beschreibung: compile(data?.beschreibung ?? ''),
+		spieltermine: compile(data?.spieltermine ?? ''),
 		email: data?.email,
 		discord: data?.discord,
 		bilder: w40KUebersichtFiles.array().parse((await w40kBilder).data)

--- a/src/routes/w40k/(blog)/uebersicht/+page.svelte
+++ b/src/routes/w40k/(blog)/uebersicht/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ProjektUebersicht from '$lib/components/projektUebersicht.svelte';
 	import { getImageUrl } from '$lib/util';
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -11,12 +12,19 @@
 			imgurl: getImageUrl(e.directus_files_id)
 		};
 	});
+	let beschreibung = '';
+	let spieltermine = '';
+
+	onMount(() => {
+		beschreibung = data.beschreibung?.code ?? '';
+		spieltermine = data.spieltermine?.code ?? '';
+	});
 </script>
 
 <ProjektUebersicht
 	titel="Warhammer 40K"
-	beschreibung={data.beschreibung?.code ?? ''}
-	spieltermine={data.spieltermine?.code ?? ''}
+	{beschreibung}
+	{spieltermine}
 	email={data.email ?? ''}
 	{images}
 />


### PR DESCRIPTION
- Eingebetteter Markdown und HTML Code werden nun im onMount() der Seiten korrekt gesetzt
- Refactor der betroffenen load-Methoden, um den Markdown-Compile zu parallelisieren