### PR TITLE
fix: falscher zeilenumbruch entfernt

### DIFF
--- a/src/lib/components/projektUebersicht.svelte
+++ b/src/lib/components/projektUebersicht.svelte
@@ -33,8 +33,8 @@
 		</P>
 
 		<Heading tag="h2">Kontakt</Heading>
-		<div class="grid grid-cols-min-content-first grid-rows-2 gap-x-2">
-			<P>E-Mail</P>
+		<div class="grid grid-cols-min-content-first grid-rows-1 gap-x-2 mb-4">
+			<P whitespace="pre">E-Mail</P>
 			<A href={`mailto:${email}`}>{email}</A>
 		</div>
 	</div>


### PR DESCRIPTION
- In Chomium-basierten Browsern wurde "E-Mail" falsch umgebrochen, eventuell weil "-" als Newline gewertet wurde. Tritt mit whitespace="pre" nicht mehr auf
- Unnötige grid-row entfernt
- Margin unterhalb des E-Mail-divs eingefügt, damit im Mobile-Modus die Bildergalerie nicht zu nah am Text erscheint