### PR TITLE
feat: google kalendar eingefügt

### DIFF
--- a/src/lib/components/googleCalendar.svelte
+++ b/src/lib/components/googleCalendar.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	export let src: string;
+	export let size: 'normal' | 'small' = 'normal';
+</script>
+
+<div class="w-full shadow-lg dark:shadow-gray-800 overflow-hidden mt-4 border-2 border-gray-300">
+	<iframe
+		title="Spielort Karte"
+		src={`${src}&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FBerlin&showCalendars=0&showTabs=0&showDate=1&showNav=1&showTitle=0&showPrint=0&mode=${
+			size === 'normal' ? 'MONTH' : 'AGENDA'
+		}&hl=de`}
+		style="width: 100%;"
+		allowfullscreen={true}
+		loading="lazy"
+		referrerpolicy="no-referrer-when-downgrade"
+		scrolling="no"
+		frameborder="0"
+		height="600"
+	/>
+</div>

--- a/src/lib/components/projektUebersicht.svelte
+++ b/src/lib/components/projektUebersicht.svelte
@@ -2,6 +2,7 @@
 	import type { ImageInformation } from '$lib/types/imageInformation';
 	import { isNullOrUndefined } from '$lib/util';
 	import { A, Heading, P } from 'flowbite-svelte';
+	import GoogleCalendar from './googleCalendar.svelte';
 	import ImageCarousel from './imageCarousel.svelte';
 
 	export let titel: string;
@@ -9,8 +10,12 @@
 	export let spieltermine: string;
 	export let email: string;
 	export let images: ImageInformation[] | undefined = undefined;
+	export let googleCalendarLink: string | undefined | null = undefined;
+
+	let innerWidth: number;
 </script>
 
+<svelte:window bind:innerWidth />
 <Heading tag="h1" class="mb-4">{titel}</Heading>
 
 <div class="flex flex-col-reverse md:inline-block md:container">
@@ -35,3 +40,7 @@
 		</div>
 	</div>
 </div>
+
+{#if googleCalendarLink}
+	<GoogleCalendar src={googleCalendarLink} size={innerWidth >= 768 ? 'normal' : 'small'} />
+{/if}

--- a/src/lib/types/zod/projektUebersicht.ts
+++ b/src/lib/types/zod/projektUebersicht.ts
@@ -4,7 +4,8 @@ export const projektUebersicht = z.object({
 	id: z.string().or(z.number()).optional(),
 	beschreibung: z.string(),
 	spieltermine: z.string(),
-	email: z.string().email()
+	email: z.string().email(),
+	google_calendar_link: z.string().url().optional().nullable()
 });
 
 export type ProjektUebersicht = z.infer<typeof projektUebersicht>;

--- a/src/routes/camarilla/(blog)/uebersicht/+page.server.ts
+++ b/src/routes/camarilla/(blog)/uebersicht/+page.server.ts
@@ -10,7 +10,7 @@ export const load = (async () => {
 	return {
 		beschreibung: compile((await response).beschreibung ?? ''),
 		spieltermine: compile((await response).spieltermine ?? ''),
-		email: (await response).email,
-		bilder
+		bilder,
+		camarillaUebersicht: response
 	};
 }) satisfies PageServerLoad;

--- a/src/routes/camarilla/(blog)/uebersicht/+page.svelte
+++ b/src/routes/camarilla/(blog)/uebersicht/+page.svelte
@@ -17,6 +17,7 @@
 	titel="Vampire Live - Camarilla"
 	beschreibung={data.beschreibung?.code ?? ''}
 	spieltermine={data.spieltermine?.code ?? ''}
-	email={data.email}
+	email={data.camarillaUebersicht.email}
 	{images}
+	googleCalendarLink={data.camarillaUebersicht.google_calendar_link}
 />

--- a/src/routes/sabbat/(blog)/uebersicht/+page.server.ts
+++ b/src/routes/sabbat/(blog)/uebersicht/+page.server.ts
@@ -10,7 +10,7 @@ export const load = (async () => {
 	return {
 		beschreibung: compile((await response).beschreibung ?? ''),
 		spieltermine: compile((await response).spieltermine ?? ''),
-		email: (await response).email,
-		bilder
+		bilder,
+		sabbatUebersicht: response
 	};
 }) satisfies PageServerLoad;

--- a/src/routes/sabbat/(blog)/uebersicht/+page.svelte
+++ b/src/routes/sabbat/(blog)/uebersicht/+page.svelte
@@ -17,6 +17,7 @@
 	titel="Vampire Live - Sabbat"
 	beschreibung={data.beschreibung?.code ?? ''}
 	spieltermine={data.spieltermine?.code ?? ''}
-	email={data.email}
+	email={data.sabbatUebersicht.email}
 	{images}
+	googleCalendarLink={data.sabbatUebersicht.google_calendar_link}
 />

--- a/src/routes/w40k/(blog)/uebersicht/+page.server.ts
+++ b/src/routes/w40k/(blog)/uebersicht/+page.server.ts
@@ -10,7 +10,7 @@ export const load = (async () => {
 	return {
 		beschreibung: compile((await response).beschreibung ?? ''),
 		spieltermine: compile((await response).spieltermine ?? ''),
-		email: (await response).email,
-		bilder
+		bilder,
+		w40kUebersicht: response
 	};
 }) satisfies PageServerLoad;

--- a/src/routes/w40k/(blog)/uebersicht/+page.svelte
+++ b/src/routes/w40k/(blog)/uebersicht/+page.svelte
@@ -17,6 +17,7 @@
 	titel="Warhammer 40K"
 	beschreibung={data.beschreibung?.code ?? ''}
 	spieltermine={data.spieltermine?.code ?? ''}
-	email={data.email}
+	email={data.w40kUebersicht.email}
 	{images}
+	googleCalendarLink={data.w40kUebersicht.google_calendar_link}
 />


### PR DESCRIPTION
- Auf den Projektsübersichtsseiten wird nun der Google Kalendar angezeigt
- Die Art der Darstellung (Listen- vs Monats-Ansicht) des Kalendars ist abhängig von der Viewport-Breite