### PR TITLE
feat: projektleiter status wird auf der orga seite angezeigt

### DIFF
--- a/src/lib/components/orgaEntry.svelte
+++ b/src/lib/components/orgaEntry.svelte
@@ -17,7 +17,12 @@
 	<div class="flex flex-col md:grid md:grid-cols-2 md:grid-rows-1 mt-2 mb-2">
 		{#each personen as person}
 			<div class="flex flex-col items-center mb-2 last:mb-0">
-				<P weight="semibold">{person.name}</P>
+				<P weight="semibold">
+					{person.name}
+					{#if person.projektleiter}
+						{` (Projektleiter)`}
+					{/if}
+				</P>
 				{#if person.bild}
 					<img
 						alt={`Bild der Spielleitung ${person.name}`}

--- a/src/lib/types/zod/orga.ts
+++ b/src/lib/types/zod/orga.ts
@@ -5,7 +5,8 @@ export const orga = z.object({
 	name: z.string(),
 	rolle: orgaRollen,
 	email: z.string().email().nullable(),
-	bild: z.string().optional()
+	bild: z.string().optional(),
+	projektleiter: z.boolean()
 });
 
 export type Orga = z.infer<typeof orga>;


### PR DESCRIPTION
- Auf der Orga-Seite wird nun optional der Projektleiterstatus angezeigt
- Orga-Typ um Projektleiter-Boolean erweitert